### PR TITLE
removing large files from repo -- fix later

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.csv filter=lfs diff=lfs merge=lfs -text
+# output/*.csv filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 ## Added by us
 
 data/comscore/
-output/weeks_machines_domains.csv
+# TODO: later come back to this and put small files in output/
+# and large files in git LFS
+# for now, while work in progress, not using git LFS
+output/
+# output/weeks_machines_domains.csv
+
 
 ## Default good things
 

--- a/output/state_census.csv
+++ b/output/state_census.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:48038f72633378a585ce9e5302012f09ec1880fce751f16cf46491b69846eb1b
-size 10563

--- a/output/us_census.csv
+++ b/output/us_census.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7983ee44e8ae57aa343be92153594e4cfc100fc1121a142bd4cd8b3774e774dc
-size 494

--- a/output/zip_census.csv
+++ b/output/zip_census.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0daf891ac88c414fd8e1631f7625780ee8ec0d5d21fdbfe4330e1ad96186317
-size 920632


### PR DESCRIPTION
- we are blocked by LFS limits
- we are not properly using LFS at the moment
- we have stored all large csv files and file changes in /output to git LFS
- this PR removes files in /output
- puts output files in .gitignore
- disables git LFS via .gitattributes

TODO later: store final large files in LFS. this may require deleting and recreating the repo.